### PR TITLE
chore: upgrade requirements with py3.8

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,5 +3,4 @@
 
 Flask
 requests
-
--e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
+edx-codejail

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,33 +4,35 @@
 #
 #    make upgrade
 #
--e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
-    # via -r requirements/base.in
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via requests
 charset-normalizer==2.0.12
     # via requests
-click==8.1.2
+click==8.1.3
     # via flask
-flask==2.1.1
+edx-codejail==3.2.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+flask==2.1.2
     # via -r requirements/base.in
 idna==3.3
     # via requests
-importlib-metadata==4.11.3
+importlib-metadata==4.11.4
     # via flask
 itsdangerous==2.1.2
     # via flask
-jinja2==3.1.1
+jinja2==3.1.2
     # via flask
 markupsafe==2.1.1
     # via jinja2
 requests==2.27.1
     # via -r requirements/base.in
 six==1.16.0
-    # via codejail
+    # via edx-codejail
 urllib3==1.26.9
     # via requests
-werkzeug==2.1.1
+werkzeug==2.1.2
     # via flask
 zipp==3.8.0
     # via importlib-metadata

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -7,3 +7,4 @@
 # link to other information that will help people in the future to remove the
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
+edx-codejail==3.2.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,13 +4,11 @@
 #
 #    make upgrade
 #
--e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
-    # via -r requirements/base.txt
-astroid==2.11.3
+astroid==2.11.5
     # via pylint
 attrs==21.4.0
     # via pytest
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via
     #   -r requirements/base.txt
     #   requests
@@ -18,21 +16,25 @@ charset-normalizer==2.0.12
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.1.2
+click==8.1.3
     # via
     #   -r requirements/base.txt
     #   flask
-coverage==6.3.2
+coverage==6.4
     # via -r requirements/dev.in
-dill==0.3.4
+dill==0.3.5.1
     # via pylint
-flask==2.1.1
+edx-codejail==3.2.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+flask==2.1.2
     # via -r requirements/base.txt
 idna==3.3
     # via
     #   -r requirements/base.txt
     #   requests
-importlib-metadata==4.11.3
+importlib-metadata==4.11.4
     # via
     #   -r requirements/base.txt
     #   flask
@@ -46,7 +48,7 @@ itsdangerous==2.1.2
     #   flask
 jedi==0.18.1
     # via pudb
-jinja2==3.1.1
+jinja2==3.1.2
     # via
     #   -r requirements/base.txt
     #   flask
@@ -78,9 +80,9 @@ pydocstyle==6.1.1
     # via -r requirements/dev.in
 pygments==2.12.0
     # via pudb
-pylint==2.13.7
+pylint==2.13.9
     # via -r requirements/dev.in
-pyparsing==3.0.8
+pyparsing==3.0.9
     # via packaging
 pytest==7.1.2
     # via -r requirements/dev.in
@@ -89,7 +91,7 @@ requests==2.27.1
 six==1.16.0
     # via
     #   -r requirements/base.txt
-    #   codejail
+    #   edx-codejail
 snowballstemmer==2.2.0
     # via pydocstyle
 tomli==2.0.1
@@ -110,11 +112,11 @@ urwid==2.1.2
     #   urwid-readline
 urwid-readline==0.13
     # via pudb
-werkzeug==2.1.1
+werkzeug==2.1.2
     # via
     #   -r requirements/base.txt
     #   flask
-wrapt==1.14.0
+wrapt==1.14.1
     # via astroid
 zipp==3.8.0
     # via

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-click==8.1.2
+click==8.1.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.6.0
+pip-tools==6.6.1
     # via -r requirements/pip-tools.in
 tomli==2.0.1
     # via pep517

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.0.4
+pip==22.1.1
     # via -r requirements/pip.in
-setuptools==62.1.0
+setuptools==62.3.2
     # via -r requirements/pip.in


### PR DESCRIPTION
### Description
This PR upgrades requirements using python 3.8. It also installs `edx-codejail `from pypi instead of source