### PR TITLE
fix: always use `codejail.safe_exec.safe_exec` when executing code

### DIFF
--- a/codejailservice/routes/code_exec_service.py
+++ b/codejailservice/routes/code_exec_service.py
@@ -28,7 +28,7 @@ def code_exec():
     # Lazy imports of codejail functions according(after) the configuration  app.
     (
         safe_exec_exception,
-        codejail_not_safe_exec,
+        _,
         codejail_safe_exec,
     ) = import_code_jail_safe_exec()
 
@@ -37,9 +37,7 @@ def code_exec():
 
     unsafely = payload["unsafely"]
     if unsafely:
-        exec_fn = codejail_not_safe_exec
-    else:
-        exec_fn = codejail_safe_exec
+        log.warning("Ignoring execution with unsafely=true")
 
     try:
         python_path = payload["python_path"]
@@ -55,7 +53,7 @@ def code_exec():
             course_id,
         )
         start = timeit.default_timer()
-        exec_fn(
+        codejail_safe_exec(
             payload["code"],
             globals_dict,
             python_path=python_path,

--- a/codejailservice/tests/test_code_exec_service.py
+++ b/codejailservice/tests/test_code_exec_service.py
@@ -103,7 +103,7 @@ class CodeExecServiceTest(BaseTestCase):
 
         self.assertEqual(200, response.status_code)
         self.assertDictEqual(expected_result, response.json)
-        unsafe_exec.assert_called_once_with(
+        safe_exec.assert_called_once_with(
             payload["code"],
             payload["globals_dict"],
             python_path=payload["python_path"],
@@ -111,7 +111,7 @@ class CodeExecServiceTest(BaseTestCase):
             limit_overrides_context=payload["limit_overrides_context"],
             slug=payload["slug"],
         )
-        safe_exec.assert_not_called()
+        unsafe_exec.assert_not_called()
 
     @mock.patch("codejailservice.routes.code_exec_service.import_code_jail_safe_exec")
     def test_unsafe_code_exec_failure(self, import_code_jail_safe_exec):
@@ -128,7 +128,7 @@ class CodeExecServiceTest(BaseTestCase):
             unsafe_exec,
             safe_exec,
         )
-        unsafe_exec.side_effect = Exception("SyntaxError: invalid syntax ' with status code: 1")
+        safe_exec.side_effect = Exception("SyntaxError: invalid syntax ' with status code: 1")
         payload = {
             "code": "Syntax error",
             "globals_dict": {"seed": 1, "anonymous_student_id": "student"},
@@ -152,6 +152,7 @@ class CodeExecServiceTest(BaseTestCase):
         self.assertEqual(200, response.status_code)
         self.assertEqual(expected_result['emsg'], response.json["emsg"])
         self.assertEqual(expected_result['globals_dict'], response.json["globals_dict"])
+        unsafe_exec.assert_not_called()
 
     @mock.patch("codejailservice.routes.code_exec_service.import_code_jail_safe_exec")
     def test_safe_code_exec_failure(self, import_code_jail_safe_exec):
@@ -192,3 +193,4 @@ class CodeExecServiceTest(BaseTestCase):
         self.assertEqual(200, response.status_code)
         self.assertEqual(expected_result['emsg'], response.json["emsg"])
         self.assertEqual(expected_result['globals_dict'], response.json["globals_dict"])
+        unsafe_exec.assert_not_called()


### PR DESCRIPTION
Usage of unsafely is determined by the setting
`COURSES_WITH_UNSAFE_CODE` in the edx-platform code, when True, the jailed code would skip the sandboxed environment and run directly on the service environment.

Allowing the use of unsafely through an HTTP call is an unnecesary vector.